### PR TITLE
Add contact number to contact page and footer

### DIFF
--- a/src/components/ContactInfo/ContactInfo.js
+++ b/src/components/ContactInfo/ContactInfo.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from './ContactInfo.module.css';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import EmailIcon from '@mui/icons-material/Email';
+import PhoneIcon from '@mui/icons-material/Phone';
 
 const ContactInfo = () => {
   return (
@@ -26,6 +27,13 @@ const ContactInfo = () => {
           <h3>Email Us</h3>
           <p><a href="mailto:info@pegasustradinghk.com">info@pegasustradinghk.com</a></p>
           <p><a href="mailto:sales@pegasustradinghk.com">sales@pegasustradinghk.com</a></p>
+        </div>
+      </div>
+      <div className={styles.infoItem}>
+        <PhoneIcon className={styles.icon} sx={{ fontSize: '1.8rem' }} />
+        <div>
+          <h3>Call Us</h3>
+          <p>+852 5434 0615</p>
         </div>
       </div>
        <div className={styles.mapContainer}>

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -36,6 +36,7 @@ const Footer = () => {
           <h4>Get In Touch</h4>
           <p>Unit B1, 21/f, Gaylord Comm Building, 114-118 Lockhart Road, Wan Chai, Hong Kong</p>
           <p>Email: info@pegasustradinghk.com</p>
+          <p>Phone: +852 5434 0615</p>
         </div>
         <div className={styles.footerSocial}>
             <h4>Follow Us</h4>


### PR DESCRIPTION
Adds the phone number +852 5434 0615 to:
- The contact information section on the Contact Us page, including a phone icon.
- The footer section, directly below the email address.

This makes it easier for you to find the contact phone number.